### PR TITLE
SEP 004: Precedence rules governing potentially conflicting role sets.

### DIFF
--- a/sep_004.md
+++ b/sep_004.md
@@ -137,6 +137,8 @@ subcomponents for the RBS and the start codon.
 We specify `SequenceAnnotation.role` and `Component.role` in analogy to
 `Participation.role` ([SBOL] 7.9.4) and `ComponentDefinition.role` ([SBOL] 7.1):
 
+### SequenceAnnotation.role
+
 The `SequenceAnnotation.role` property is an OPTIONAL set of URIs describing
 the purpose or potential function of a given subsequence (and, if given, a
 child `ComponentDefinition`) in the context of its parent `ComponentDefinition`.
@@ -145,19 +147,13 @@ terms from appropriate ontologies. Roles are not restricted to describing
 biological function; they may annotate sequences' function in any domain for
 which an ontology exists.
 
-The `Component.role` property is an OPTIONAL set of URIs that describes
-the purpose or potential function of a given child `ComponentDefinition` in the
-context of its parent `ComponentDefinition`. If provided, the `role` property
-MUST encode one or more URIs that MUST identify terms from appropriate
-ontologies. Roles are not restricted to describing biological function; they may
-annotate sequences' function in any domain for which an ontology exists.
-
 It is RECOMMENDED that these URIs identify terms that are compatible with the
 `type` properties of both the parent and child ComponentDefinitions. For
 example, the `role` property of a `SequenceAnnotation` which belongs to a
-`ComponentDefinition` of type DNA and points to a child `ComponentDefinition` of
-type DNA might refer to terms from the Sequence Ontology. A table of recommended
-ontology branches is given in the [SBOL] specification.
+`ComponentDefinition` of type DNA and incorporates a grandchild
+`ComponentDefinition` of type DNA might refer to terms from the Sequence
+Ontology. A table of recommended ontology branches is given in the [SBOL]
+specification.
 
 Higher-level roles take precedence. If a `SequenceAnnotation` has a set of one or
 more roles and either its optional child `Component` and/or the grandchild
@@ -176,6 +172,22 @@ grandchild `ComponentDefinition`.
 
 If a SequenceAnnotation's set of roles contain multiple URIs, then they MUST
 identify non-conflicting terms (refer to examples in the [SBOL] spec).
+
+### Component.role
+
+The `Component.role` property is an OPTIONAL set of URIs that describes
+the purpose or potential function of a given child `ComponentDefinition` in the
+context of its parent `ComponentDefinition`. If provided, the `role` property
+MUST encode one or more URIs that MUST identify terms from appropriate
+ontologies. Roles are not restricted to describing biological function; they may
+annotate sequences' function in any domain for which an ontology exists.
+
+It is RECOMMENDED that these URIs identify terms that are compatible with the
+`type` properties of both the parent and child ComponentDefinitions. For
+example, the `role` property of a `Component` which belongs to a
+`ComponentDefinition` of type DNA and points to a child `ComponentDefinition` of
+type DNA might refer to terms from the Sequence Ontology. A table of recommended
+ontology branches is given in the [SBOL] specification.
 
 Higher-level roles take precedence. If a `Component` has a set of one or more
 roles and its child `ComponentDefinition` also has a set of one or more roles,

--- a/sep_004.md
+++ b/sep_004.md
@@ -137,7 +137,7 @@ subcomponents for the RBS and the start codon.
 We specify `SequenceAnnotation.role` and `Component.role` in analogy to
 `Participation.role` ([SBOL] 7.9.4) and `ComponentDefinition.role` ([SBOL] 7.1):
 
-### Component.role
+### 2.1 Component.role
 
 The `Component.role` property is an OPTIONAL set of URIs that describes
 the purpose or potential function of a given child `ComponentDefinition` in the
@@ -166,7 +166,7 @@ those roles differ from any roles already belonging to its child
 If a Component's set of roles contain multiple URIs, then they MUST identify
 non-conflicting terms (refer to examples in the [SBOL] spec).
 
-### SequenceAnnotation.role
+### 2.2 SequenceAnnotation.role
 
 The `SequenceAnnotation.role` property is an OPTIONAL set of URIs describing
 the purpose or potential function of a given subsequence (and, if given, a
@@ -202,7 +202,7 @@ grandchild `ComponentDefinition`.
 If a SequenceAnnotation's set of roles contain multiple URIs, then they MUST
 identify non-conflicting terms (refer to examples in the [SBOL] spec).
 
-### Editorial remark
+### 2.3 Editorial remark
 
 The language about "non-conflicting terms" is boilerplate extracted from the
 current [SBOL] 2.0 spec. It is evidently vague and open-ended. Note that the

--- a/sep_004.md
+++ b/sep_004.md
@@ -1,16 +1,16 @@
 SEP 004 -- Add contextual role properties to SequenceAnnotation and Component
 ===================================
-SEP                     | 004
+SEP                   | 004
 ----------------------|--------------
-**Title**                | Add contextual role properties to SequenceAnnotation and Component
+**Title**             | Add contextual role properties to SequenceAnnotation and Component
 **Authors**           | Mike Bissell (bissell at amyris.com), Raik Gruenberg (raik dot gruenberg at gmail), Chris Macklin (macklin at amyris.com)
-**Editor**             | Bryan Bartley
-**Type**               | Data Model
-**SBOL Version** | 2.1.0 (TBD)
-**Replaces**        |
-**Status**             | Draft
-**Created**          | 10-Oct-2015
-**Last modified**  | 22-Feb-2016
+**Editor**            | Bryan Bartley
+**Type**              | Data Model
+**SBOL Version**      | 2.1.0 (TBD)
+**Replaces**          |
+**Status**            | Draft
+**Created**           | 10-Oct-2015
+**Last modified**     | 22-Feb-2016
 
 Abstract
 --------

--- a/sep_004.md
+++ b/sep_004.md
@@ -135,8 +135,7 @@ subcomponents for the RBS and the start codon.
 ----------------
 
 We specify `SequenceAnnotation.role` and `Component.role` in analogy to
-`Participation.role` ([SBOL] 7.9.4) and
-`ComponentDefinition.role` ([SBOL] 7.1):
+`Participation.role` ([SBOL] 7.9.4) and `ComponentDefinition.role` ([SBOL] 7.1):
 
 The `SequenceAnnotation.role` property is an OPTIONAL set of URIs describing
 the purpose or potential function of a given subsequence (and, if given, a
@@ -169,6 +168,11 @@ identify non-conflicting terms (refer to examples in the [SBOL] spec).
 
 It is RECOMMENDED to specify `role` properties on a `Component` only if
 they differ from the roles already on the child `ComponentDefinition`.
+
+If a `Component` has a set of one or more roles and its child
+`ComponentDefinition` also has a set of one or more roles, then the `Component`
+role set completely overrides the set of roles on its child
+`ComponentDefinition`. Tools must not merge the contents of the two sets.
 
 If a Component's set of roles contain multiple URIs, then they MUST identify
 non-conflicting terms (refer to examples in the [SBOL] spec).

--- a/sep_004.md
+++ b/sep_004.md
@@ -24,7 +24,7 @@ SBOL already permits roles on `ComponentDefinition` instances, however the
 declared roles that were originally imagined and encoded by the author of a
 `ComponentDefinition` may not accurately reflect the roles of that
 part in every biological and operational context. In practice, context often
-takes precedence in the determination of a part's actual roles.  For example, a
+takes precedence in the determination of a part's actual roles. For example, a
 DNA sequence encoding a protein purification tag might, in a particular design,
 be used merely as a benign spacer between two DNA elements.
 

--- a/sep_004.md
+++ b/sep_004.md
@@ -166,16 +166,25 @@ they differ from the roles already present on the child `ComponentDefinition`
 If a SequenceAnnotation's set of roles contain multiple URIs, then they MUST
 identify non-conflicting terms (refer to examples in the [SBOL] spec).
 
+Higher-level roles take precedce. If a `SequenceAnnotation` has a set of one or
+more roles and either its optional child `Component` and/or the grandchild
+`ComponentDefinition` also has its own set of one or more roles, then the
+`SequenceAnnotation` role set completely overrides all roles on its child
+`Component` and grandchild `ComponentDefinition` with respect to the region
+of the parent `Sequence` annotated by that `SequenceAnnotation`. Tools must not
+merge the potentially conflicting contents of the three sets.
+
 It is RECOMMENDED to specify `role` properties on a `Component` only if
 they differ from the roles already on the child `ComponentDefinition`.
 
-If a `Component` has a set of one or more roles and its child
-`ComponentDefinition` also has a set of one or more roles, then the `Component`
-role set completely overrides the set of roles on its child
-`ComponentDefinition`. Tools must not merge the contents of the two sets.
-
 If a Component's set of roles contain multiple URIs, then they MUST identify
 non-conflicting terms (refer to examples in the [SBOL] spec).
+
+Higher-level roles take precedce. If a `Component` has a set of one or more
+roles and its child `ComponentDefinition` also has a set of one or more roles,
+then the `Component` role set completely overrides all roles on its child
+`ComponentDefinition`. Tools must not merge the potentially conflicting contents
+of the two sets.
 
 (The language about "non-conflicting terms" is boilerplate extracted from the
 current [SBOL] 2.0 spec. It is evidently vague and open-ended. Note that the

--- a/sep_004.md
+++ b/sep_004.md
@@ -137,6 +137,35 @@ subcomponents for the RBS and the start codon.
 We specify `SequenceAnnotation.role` and `Component.role` in analogy to
 `Participation.role` ([SBOL] 7.9.4) and `ComponentDefinition.role` ([SBOL] 7.1):
 
+### Component.role
+
+The `Component.role` property is an OPTIONAL set of URIs that describes
+the purpose or potential function of a given child `ComponentDefinition` in the
+context of its parent `ComponentDefinition`. If provided, the `role` property
+MUST encode one or more URIs that MUST identify terms from appropriate
+ontologies. Roles are not restricted to describing biological function; they may
+annotate sequences' function in any domain for which an ontology exists.
+
+It is RECOMMENDED that these URIs identify terms that are compatible with the
+`type` properties of both the parent and child ComponentDefinitions. For
+example, the `role` property of a `Component` which belongs to a
+`ComponentDefinition` of type DNA and points to a child `ComponentDefinition` of
+type DNA might refer to terms from the Sequence Ontology. A table of recommended
+ontology branches is given in the [SBOL] specification.
+
+Higher-level roles take precedence. If a `Component` has a set of one or more
+roles and its child `ComponentDefinition` also has a set of one or more roles,
+then the `Component` role set completely overrides all roles on its child
+`ComponentDefinition`. Tools must not merge the potentially conflicting contents
+of the two sets.
+
+It is RECOMMENDED to specify `role` properties on a `Component` only if
+those roles differ from any roles already belonging to its child
+`ComponentDefinition`.
+
+If a Component's set of roles contain multiple URIs, then they MUST identify
+non-conflicting terms (refer to examples in the [SBOL] spec).
+
 ### SequenceAnnotation.role
 
 The `SequenceAnnotation.role` property is an OPTIONAL set of URIs describing
@@ -173,36 +202,9 @@ grandchild `ComponentDefinition`.
 If a SequenceAnnotation's set of roles contain multiple URIs, then they MUST
 identify non-conflicting terms (refer to examples in the [SBOL] spec).
 
-### Component.role
+### Editorial remark
 
-The `Component.role` property is an OPTIONAL set of URIs that describes
-the purpose or potential function of a given child `ComponentDefinition` in the
-context of its parent `ComponentDefinition`. If provided, the `role` property
-MUST encode one or more URIs that MUST identify terms from appropriate
-ontologies. Roles are not restricted to describing biological function; they may
-annotate sequences' function in any domain for which an ontology exists.
-
-It is RECOMMENDED that these URIs identify terms that are compatible with the
-`type` properties of both the parent and child ComponentDefinitions. For
-example, the `role` property of a `Component` which belongs to a
-`ComponentDefinition` of type DNA and points to a child `ComponentDefinition` of
-type DNA might refer to terms from the Sequence Ontology. A table of recommended
-ontology branches is given in the [SBOL] specification.
-
-Higher-level roles take precedence. If a `Component` has a set of one or more
-roles and its child `ComponentDefinition` also has a set of one or more roles,
-then the `Component` role set completely overrides all roles on its child
-`ComponentDefinition`. Tools must not merge the potentially conflicting contents
-of the two sets.
-
-It is RECOMMENDED to specify `role` properties on a `Component` only if
-those roles differ from any roles already belonging to its child
-`ComponentDefinition`.
-
-If a Component's set of roles contain multiple URIs, then they MUST identify
-non-conflicting terms (refer to examples in the [SBOL] spec).
-
-(The language about "non-conflicting terms" is boilerplate extracted from the
+The language about "non-conflicting terms" is boilerplate extracted from the
 current [SBOL] 2.0 spec. It is evidently vague and open-ended. Note that the
 [SBOL] spec remains silent on the topic of how to interpret "non-conflicting,"
 because this will depend on the interpretation of these roles, a matter which
@@ -210,7 +212,7 @@ lies well outside the scope of [SBOL], as noted under `ModuleDefinition`:
 "Interpretation of the meaning of such roles currently depends on the software
 tools that read and write them." ([SBOL]) Given this vagueness, someone might
 wish to propose in a separate SEP to eliminate this boilerplate, as it provides
-no specific guidance to SBOL software developers.)
+no specific guidance to SBOL software developers.
 
 
 3. Examples

--- a/sep_004.md
+++ b/sep_004.md
@@ -159,6 +159,14 @@ example, the `role` property of a `SequenceAnnotation` which belongs to a
 type DNA might refer to terms from the Sequence Ontology. A table of recommended
 ontology branches is given in the [SBOL] specification.
 
+Higher-level roles take precedence. If a `SequenceAnnotation` has a set of one or
+more roles and either its optional child `Component` and/or the grandchild
+`ComponentDefinition` also has its own set of one or more roles, then the
+`SequenceAnnotation` role set completely overrides all roles on its child
+`Component` and grandchild `ComponentDefinition` with respect to the region
+of the parent `Sequence` annotated by that `SequenceAnnotation`. Tools must not
+merge the potentially conflicting contents of the three sets.
+
 It is RECOMMENDED to specify `role` properties on a `SequenceAnnotation` only if
 those roles differ from any roles already belonging to its optional child
 `Component` (if a child exists). If a child `Component` exists but it has no
@@ -169,13 +177,11 @@ grandchild `ComponentDefinition`.
 If a SequenceAnnotation's set of roles contain multiple URIs, then they MUST
 identify non-conflicting terms (refer to examples in the [SBOL] spec).
 
-Higher-level roles take precedence. If a `SequenceAnnotation` has a set of one or
-more roles and either its optional child `Component` and/or the grandchild
-`ComponentDefinition` also has its own set of one or more roles, then the
-`SequenceAnnotation` role set completely overrides all roles on its child
-`Component` and grandchild `ComponentDefinition` with respect to the region
-of the parent `Sequence` annotated by that `SequenceAnnotation`. Tools must not
-merge the potentially conflicting contents of the three sets.
+Higher-level roles take precedence. If a `Component` has a set of one or more
+roles and its child `ComponentDefinition` also has a set of one or more roles,
+then the `Component` role set completely overrides all roles on its child
+`ComponentDefinition`. Tools must not merge the potentially conflicting contents
+of the two sets.
 
 It is RECOMMENDED to specify `role` properties on a `Component` only if
 those roles differ from any roles already belonging to its child
@@ -183,12 +189,6 @@ those roles differ from any roles already belonging to its child
 
 If a Component's set of roles contain multiple URIs, then they MUST identify
 non-conflicting terms (refer to examples in the [SBOL] spec).
-
-Higher-level roles take precedence. If a `Component` has a set of one or more
-roles and its child `ComponentDefinition` also has a set of one or more roles,
-then the `Component` role set completely overrides all roles on its child
-`ComponentDefinition`. Tools must not merge the potentially conflicting contents
-of the two sets.
 
 (The language about "non-conflicting terms" is boilerplate extracted from the
 current [SBOL] 2.0 spec. It is evidently vague and open-ended. Note that the

--- a/sep_004.md
+++ b/sep_004.md
@@ -160,13 +160,16 @@ type DNA might refer to terms from the Sequence Ontology. A table of recommended
 ontology branches is given in the [SBOL] specification.
 
 It is RECOMMENDED to specify `role` properties on a `SequenceAnnotation` only if
-they differ from the roles already present on the child `ComponentDefinition`
-(if a child exists).
+those roles differ from any roles already belonging to its optional child
+`Component` (if a child exists). If a child `Component` exists but it has no
+roles, then it is RECOMMENDED to specify `role` properties on a
+`SequenceAnnotation` only if they differ from any roles already belonging to the
+grandchild `ComponentDefinition`.
 
 If a SequenceAnnotation's set of roles contain multiple URIs, then they MUST
 identify non-conflicting terms (refer to examples in the [SBOL] spec).
 
-Higher-level roles take precedce. If a `SequenceAnnotation` has a set of one or
+Higher-level roles take precedence. If a `SequenceAnnotation` has a set of one or
 more roles and either its optional child `Component` and/or the grandchild
 `ComponentDefinition` also has its own set of one or more roles, then the
 `SequenceAnnotation` role set completely overrides all roles on its child
@@ -175,12 +178,13 @@ of the parent `Sequence` annotated by that `SequenceAnnotation`. Tools must not
 merge the potentially conflicting contents of the three sets.
 
 It is RECOMMENDED to specify `role` properties on a `Component` only if
-they differ from the roles already on the child `ComponentDefinition`.
+those roles differ from any roles already belonging to its child
+`ComponentDefinition`.
 
 If a Component's set of roles contain multiple URIs, then they MUST identify
 non-conflicting terms (refer to examples in the [SBOL] spec).
 
-Higher-level roles take precedce. If a `Component` has a set of one or more
+Higher-level roles take precedence. If a `Component` has a set of one or more
 roles and its child `ComponentDefinition` also has a set of one or more roles,
 then the `Component` role set completely overrides all roles on its child
 `ComponentDefinition`. Tools must not merge the potentially conflicting contents


### PR DESCRIPTION
Per our discussion at SBOL Workshop 14, 11AM 15 March 2016.