### PR TITLE
Clarifications: Overriding roles. (SEP 004)

### DIFF
--- a/sep_004.md
+++ b/sep_004.md
@@ -159,8 +159,8 @@ then the `Component` role set completely overrides all roles on its child
 `ComponentDefinition`. Tools must not merge the potentially conflicting contents
 of the two sets.
 
-It is RECOMMENDED to specify `role` properties on a `Component` only if
-those roles differ from any roles already belonging to its child
+It is RECOMMENDED to specify a set of `role` properties on a `Component` only if
+that role set differs from the set of roles already belonging to its child
 `ComponentDefinition`.
 
 If a Component's set of roles contain multiple URIs, then they MUST identify
@@ -193,11 +193,11 @@ of the parent `Sequence` annotated by that `SequenceAnnotation`. Tools must not
 merge the potentially conflicting contents of the three sets.
 
 It is RECOMMENDED to specify `role` properties on a `SequenceAnnotation` only if
-those roles differ from any roles already belonging to its optional child
-`Component` (if a child exists). If a child `Component` exists but it has no
-roles, then it is RECOMMENDED to specify `role` properties on a
-`SequenceAnnotation` only if they differ from any roles already belonging to the
-grandchild `ComponentDefinition`.
+that set of roles differs from the set of roles already belonging to its
+optional child `Component` (if any). If a child `Component` exists but it has no
+roles, then it is RECOMMENDED to specify a set of `role` properties on a
+`SequenceAnnotation` only if that set differs from the set of roles already
+belonging to the grandchild `ComponentDefinition` (if any).
 
 If a SequenceAnnotation's set of roles contain multiple URIs, then they MUST
 identify non-conflicting terms (refer to examples in the [SBOL] spec).

--- a/sep_004.md
+++ b/sep_004.md
@@ -202,10 +202,23 @@ belonging to the child `ComponentDefinition` (if any).
 If a SequenceAnnotation's set of roles contain multiple URIs, then they MUST
 identify non-conflicting terms (refer to examples in the [SBOL] spec).
 
-### 2.3 Editorial remark
+### 2.3 XML Serialization
 
-The language about "non-conflicting terms" is boilerplate extracted from the
-current [SBOL] 2.0 spec. It is evidently vague and open-ended. Note that the
+For both proposed contextual role properties, the list of `&ltrole>` elements,
+if given, MUST be contained within a single `&ltroles>` element in its
+serialized form. By giving us a way to override a *nonempty* set of child roles
+with an *empty* set of parent roles, this structure allows us to specify that a
+child `ComponentDefinition` whose designer declared some role(s) actually has
+*no role* in the given parent context. An empty `&ltroles>` element implies an
+empty set of contextual roles for the purposes of applying the precedence rules
+in subsections 2.1 and 2.2; the empty element specifies that there are *no*
+roles in the current context. An empty `&ltroles>` element is not equivalent
+to an absent one.
+
+### 2.4 Editorial remark
+
+The language above about "non-conflicting terms" is boilerplate extracted from
+the current [SBOL] 2.0 spec. It is evidently vague and open-ended. Note that the
 [SBOL] spec remains silent on the topic of how to interpret "non-conflicting,"
 because this will depend on the interpretation of these roles, a matter which
 lies well outside the scope of [SBOL], as noted under `ModuleDefinition`:

--- a/sep_004.md
+++ b/sep_004.md
@@ -179,25 +179,25 @@ which an ontology exists.
 It is RECOMMENDED that these URIs identify terms that are compatible with the
 `type` properties of both the parent and child ComponentDefinitions. For
 example, the `role` property of a `SequenceAnnotation` which belongs to a
-`ComponentDefinition` of type DNA and incorporates a grandchild
+`ComponentDefinition` of type DNA and incorporates a child
 `ComponentDefinition` of type DNA might refer to terms from the Sequence
 Ontology. A table of recommended ontology branches is given in the [SBOL]
 specification.
 
 Higher-level roles take precedence. If a `SequenceAnnotation` has a set of one or
-more roles and either its optional child `Component` and/or the grandchild
+more roles and either its optional sibling `Component` and/or the child
 `ComponentDefinition` also has its own set of one or more roles, then the
-`SequenceAnnotation` role set completely overrides all roles on its child
-`Component` and grandchild `ComponentDefinition` with respect to the region
+`SequenceAnnotation` role set completely overrides all roles on its sibling
+`Component` and the child `ComponentDefinition` with respect to the region
 of the parent `Sequence` annotated by that `SequenceAnnotation`. Tools must not
 merge the potentially conflicting contents of the three sets.
 
 It is RECOMMENDED to specify `role` properties on a `SequenceAnnotation` only if
 that set of roles differs from the set of roles already belonging to its
-optional child `Component` (if any). If a child `Component` exists but it has no
-roles, then it is RECOMMENDED to specify a set of `role` properties on a
+optional sibling `Component` (if any). If a sibling `Component` exists but it
+has no roles, then it is RECOMMENDED to specify a set of `role` properties on a
 `SequenceAnnotation` only if that set differs from the set of roles already
-belonging to the grandchild `ComponentDefinition` (if any).
+belonging to the child `ComponentDefinition` (if any).
 
 If a SequenceAnnotation's set of roles contain multiple URIs, then they MUST
 identify non-conflicting terms (refer to examples in the [SBOL] spec).

--- a/sep_004.md
+++ b/sep_004.md
@@ -156,8 +156,8 @@ ontology branches is given in the [SBOL] specification.
 Higher-level roles take precedence. If a `Component` has a set of one or more
 roles and its child `ComponentDefinition` also has a set of one or more roles,
 then the `Component` role set completely overrides all roles on its child
-`ComponentDefinition`. Tools must not merge the potentially conflicting contents
-of the two sets.
+`ComponentDefinition` with respect to its parent `ComponentDefinition` context.
+Tools must not merge the potentially conflicting contents of the two sets.
 
 It is RECOMMENDED to specify a set of `role` properties on a `Component` only if
 that role set differs from the set of roles already belonging to its child

--- a/sep_004.md
+++ b/sep_004.md
@@ -204,15 +204,15 @@ identify non-conflicting terms (refer to examples in the [SBOL] spec).
 
 ### 2.3 XML Serialization
 
-For both proposed contextual role properties, the list of `&ltrole>` elements,
-if given, MUST be contained within a single `&ltroles>` element in its
+For both proposed contextual role properties, the list of `<role>` elements,
+if given, MUST be contained within a single `<roles>` element in its
 serialized form. By giving us a way to override a *nonempty* set of child roles
 with an *empty* set of parent roles, this structure allows us to specify that a
 child `ComponentDefinition` whose designer declared some role(s) actually has
-*no role* in the given parent context. An empty `&ltroles>` element implies an
+*no role* in the given parent context. An empty `<roles>` element implies an
 empty set of contextual roles for the purposes of applying the precedence rules
 in subsections 2.1 and 2.2; the empty element specifies that there are *no*
-roles in the current context. An empty `&ltroles>` element is not equivalent
+roles in the current context. An empty `<roles>` element is not equivalent
 to an absent one.
 
 ### 2.4 Editorial remark


### PR DESCRIPTION
Clarification. There's no need to redundantly restate role sets unless you're overriding roles. We want you to re-enumerate all the roles if you need to override them. Otherwise we have to define complicated rules of inheritance for every possible roles and ontology -- an impossible task.

Clarification. Overrides are contextual. Overriding a CD.role in one parent assembly does not override it in another.

Enhancement. Recommend a specific serialization format that allows us to encode empty sets. Blindly following the example of ComponentDefinition.role gives us no way to express the removal of all roles when overriding child roles in a context.