### PR TITLE
SEP 004: Clarify the data model. Fix typos. Polish the prose.

### DIFF
--- a/sep_004.md
+++ b/sep_004.md
@@ -143,6 +143,9 @@ The `Component.roles` property is an OPTIONAL set of zero or more `role` URIs
 describing the purpose or potential function of a given child
 `ComponentDefinition` in the context of its parent `ComponentDefinition`.
 
+The data model distinguishes between an *empty* set of `Component.roles` and an
+*absent* one.
+
 If provided, the `roles` property MUST contain zero or more `role` URIs that
 MUST identify terms from appropriate ontologies. Roles are not restricted to
 describing biological function; they may annotate Components' function in any
@@ -175,6 +178,9 @@ The `SequenceAnnotation.roles` property is an OPTIONAL set of zero or more
 `role` URIs describing the purpose or potential function of a given subsequence
 (and, if given, a child `ComponentDefinition`) in the context of its parent
 `ComponentDefinition`.
+
+The data model distinguishes between an *empty* set of
+`SequenceAnnotation.roles` and an *absent* one.
 
 If provided, the `roles` property MUST encode zero or more `role` URIs that MUST
 identify terms from appropriate ontologies. Roles are not restricted to

--- a/sep_004.md
+++ b/sep_004.md
@@ -78,8 +78,8 @@ ignoring its planned biological function in finished assemblies. Since modular
 subcomponents are typically intended for reuse in multiple finished assemblies,
 these subcomponents' eventual logical or biological roles may not even be
 determined at the time of design or compilation, however the genetic compiler
-will still need to classify their relationships to various intermediate build
-products containing them.
+will still need to classify subcomponents' relationships to various intermediate
+build products containing them.
 
 In both scenarios, non-biological roles are important because a subcomponent has
 no relevant biological activity in isolation, during design and construction.

--- a/sep_004.md
+++ b/sep_004.md
@@ -89,16 +89,17 @@ Therefore, contextual roles are needed.
 ### ARGUMENT FOR BOTH COMPONENT ROLES AND SEQUENCEANNOTATION ROLES
 
 We propose that contextual roles are required in two places:
-`SequenceAnnotation` and `Component`.
+`Component` and `SequenceAnnotation`.
 
-Adding optional `roles` fields to `SequenceAnnotation` will allow users to
-describe the part's actual design purpose in the context of a specific parent
-sequence, with respect to a specific location in that sequence.
+Adding an optional `roles` field to `Component` will allow users to describe the
+subcomponent's actual design purpose with respect to the current assembly,
+without reference to the specific details of its parent's sequence (if that
+sequence is even known yet).
 
-Adding optional `roles` fields to `Component` will allow users to describe the
-part's actual design purpose with respect to the current assembly, without
-reference to the specific details of its parent's sequence (if such a sequence
-is even known yet).
+Adding an optional `roles` field to `SequenceAnnotation` will allow users to
+describe the design purpose of a subsequence and an optional subcomponent in the
+context of a parent sequence, with respect to a specific location in that
+sequence.
 
 It is insufficient to put roles only on `SequenceAnnotation`; roles are
 additionally needed on `Component`. There are two reasons. First, not all roles
@@ -113,21 +114,22 @@ build. Compilation of the parent ComponentDefinition's sequence might even be
 deferred until later, when the host context is finally determined. Between the
 time that the subcomponents were compiled and the moment of the parent's
 compilation, subcomponents' contextual roles must be conveyed through the
-compiler toolchain, and we contend that `Component.role` is the appropriate
+compiler toolchain, and we propose that `Component.roles` is the appropriate
 location.
 
 It is insufficient to put roles only on `Component`; roles are additionally
 needed on `SequenceAnnotation`. There are, again, two reasons. First, when it is
-possible to map a subcomponent with some `role` (say, the promoter
-http://identifiers.org/so/SO:0000167) onto a specific location in a parent
+possible to map a subcomponent with some contextual `role` (say, the promoter
+http://identifiers.org/so/SO:0000167) onto a *specific location* in a parent
 sequence, then users will want to do that. Only `SequenceAnnotation` gives us
 that ability; `Component` does not refer to parent sequence details. Secondly,
 users may choose not to model every aspect of a `ComponentDefinition`
-hierarchically (using Components to link in sub-ComponentDefinitions), but these
+hierarchically (using Components to link in sub-ComponentDefinitions), but our
 users may still wish to annotate the genetic details contained in a
-ComponentDefinition's sequence. For example, the user might tag a subsequence as
-an RBS, and another sequence as a start codon, without making separate
-subcomponents for the RBS and the start codon.
+ComponentDefinition's sequence. For example, the user might tag one subsequence
+as an RBS, and another sequence as a start codon, without making separate,
+heavyweight `Component` and `ComponentDefinition` elements for the RBS and the
+start codon.
 
 
 2. Specification

--- a/sep_004.md
+++ b/sep_004.md
@@ -15,10 +15,10 @@ SEP                   | 004
 Abstract
 --------
 
-We propose adding optional `role` fields to both `SequenceAnnotation` and
-`Component`. This will allow users to specify the actual role(s) of a
-subcomponent or subsequence in the context of a design. In this document we
-refer to these two proposed `role` fields as "contextual roles."
+We propose adding optional `roles` fields to both `SequenceAnnotation` and
+`Component`. A `roles` element comprises a set of zero or more `role` members,
+which we call "contextual roles." Contextual roles will allow users to specify
+the actual role(s) of a subcomponent or subsequence in the context of a design.
 
 SBOL already permits roles on `ComponentDefinition` instances, however the
 declared roles that were originally imagined and encoded by the author of a
@@ -91,15 +91,14 @@ Therefore, contextual roles are needed.
 We propose that contextual roles are required in two places:
 `SequenceAnnotation` and `Component`.
 
-Adding an optional `role` field (with multiplicity zero to many) to
-`SequenceAnnotation` will allow users to describe the part's actual design
-purpose in the context of a specific parent sequence, with respect to a specific
-location in that sequence.
+Adding optional `roles` fields to `SequenceAnnotation` will allow users to
+describe the part's actual design purpose in the context of a specific parent
+sequence, with respect to a specific location in that sequence.
 
-Adding an optional `role` (with multiplicity zero to many) to `Component` will
-allow users to describe the part's actual design purpose with respect to the
-current assembly, without reference to the specific details of its parent's
-sequence (if such a sequence is even known yet).
+Adding optional `roles` fields to `Component` will allow users to describe the
+part's actual design purpose with respect to the current assembly, without
+reference to the specific details of its parent's sequence (if such a sequence
+is even known yet).
 
 It is insufficient to put roles only on `SequenceAnnotation`; roles are
 additionally needed on `Component`. There are two reasons. First, not all roles
@@ -122,7 +121,7 @@ needed on `SequenceAnnotation`. There are, again, two reasons. First, when it is
 possible to map a subcomponent with some `role` (say, the promoter
 http://identifiers.org/so/SO:0000167) onto a specific location in a parent
 sequence, then users will want to do that. Only `SequenceAnnotation` gives us
-that ability; Component does not refer to parent sequence details. Secondly,
+that ability; `Component` does not refer to parent sequence details. Secondly,
 users may choose not to model every aspect of a `ComponentDefinition`
 hierarchically (using Components to link in sub-ComponentDefinitions), but these
 users may still wish to annotate the genetic details contained in a
@@ -134,86 +133,98 @@ subcomponents for the RBS and the start codon.
 2. Specification
 ----------------
 
-We specify `SequenceAnnotation.role` and `Component.role` in analogy to
-`Participation.role` ([SBOL] 7.9.4) and `ComponentDefinition.role` ([SBOL] 7.1):
+We specify the contents of `SequenceAnnotation.roles` and `Component.roles` in
+analogy to `Participation.role` ([SBOL] 7.9.4) and `ComponentDefinition.role`
+([SBOL] 7.1):
 
-### 2.1 Component.role
+### 2.1 Component.roles
 
-The `Component.role` property is an OPTIONAL set of URIs that describes
-the purpose or potential function of a given child `ComponentDefinition` in the
-context of its parent `ComponentDefinition`. If provided, the `role` property
-MUST encode one or more URIs that MUST identify terms from appropriate
-ontologies. Roles are not restricted to describing biological function; they may
-annotate sequences' function in any domain for which an ontology exists.
+The `Component.roles` property is an OPTIONAL set of zero or more `role` URIs
+describing the purpose or potential function of a given child
+`ComponentDefinition` in the context of its parent `ComponentDefinition`.
 
-It is RECOMMENDED that these URIs identify terms that are compatible with the
-`type` properties of both the parent and child ComponentDefinitions. For
-example, the `role` property of a `Component` which belongs to a
-`ComponentDefinition` of type DNA and points to a child `ComponentDefinition` of
-type DNA might refer to terms from the Sequence Ontology. A table of recommended
-ontology branches is given in the [SBOL] specification.
+If provided, the `roles` property MUST contain zero or more `role` URIs that
+MUST identify terms from appropriate ontologies. Roles are not restricted to
+describing biological function; they may annotate Components' function in any
+domain for which an ontology exists.
 
-Higher-level roles take precedence. If a `Component` has a set of one or more
-roles and its child `ComponentDefinition` also has a set of one or more roles,
-then the `Component` role set completely overrides all roles on its child
-`ComponentDefinition` with respect to its parent `ComponentDefinition` context.
-Tools must not merge the potentially conflicting contents of the two sets.
+It is RECOMMENDED that these `role` URIs identify terms that are compatible with
+the `type` properties of both the parent and child ComponentDefinitions. For
+example, a `role` of a `Component` which belongs to a `ComponentDefinition` of
+type DNA and points to a child `ComponentDefinition` of type DNA might refer to
+terms from the Sequence Ontology. A table of recommended ontology branches is
+given in the [SBOL] specification.
 
-It is RECOMMENDED to specify a set of `role` properties on a `Component` only if
-that role set differs from the set of roles already belonging to its child
+Higher-level roles take precedence. If a `Component` has a set of zero or more
+`roles` and its child `ComponentDefinition` also has a set of one or more `role`
+elements, then the `Component.roles` set completely overrides all roles on its
+child `ComponentDefinition` with respect to the current parent
+`ComponentDefinition` context. Tools must not merge the potentially conflicting
+contents of the two sets.
+
+It is RECOMMENDED to specify a set of `Component.roles` only if that set of
+roles differs from the set of `role` elements already belonging to its child
 `ComponentDefinition`.
 
-If a Component's set of roles contain multiple URIs, then they MUST identify
-non-conflicting terms (refer to examples in the [SBOL] spec).
+If a Component's set of `roles` contain multiple `role` URIs, then they MUST
+identify non-conflicting terms (refer to examples in the [SBOL] spec).
 
-### 2.2 SequenceAnnotation.role
+### 2.2 SequenceAnnotation.roles
 
-The `SequenceAnnotation.role` property is an OPTIONAL set of URIs describing
-the purpose or potential function of a given subsequence (and, if given, a
-child `ComponentDefinition`) in the context of its parent `ComponentDefinition`.
-If provided, the `role` property MUST encode one or more URIs that MUST identify
-terms from appropriate ontologies. Roles are not restricted to describing
-biological function; they may annotate sequences' function in any domain for
-which an ontology exists.
+The `SequenceAnnotation.roles` property is an OPTIONAL set of zero or more
+`role` URIs describing the purpose or potential function of a given subsequence
+(and, if given, a child `ComponentDefinition`) in the context of its parent
+`ComponentDefinition`.
 
-It is RECOMMENDED that these URIs identify terms that are compatible with the
-`type` properties of both the parent and child ComponentDefinitions. For
-example, the `role` property of a `SequenceAnnotation` which belongs to a
+If provided, the `roles` property MUST encode zero or more `role` URIs that MUST
+identify terms from appropriate ontologies. Roles are not restricted to
+describing biological function; they may annotate Sequences' function in any
+domain for which an ontology exists.
+
+It is RECOMMENDED that these `role` URIs identify terms that are compatible with
+the `type` properties of both the parent and child ComponentDefinitions (if
+given). For example, a `role` of a `SequenceAnnotation` which belongs to a
 `ComponentDefinition` of type DNA and incorporates a child
 `ComponentDefinition` of type DNA might refer to terms from the Sequence
 Ontology. A table of recommended ontology branches is given in the [SBOL]
 specification.
 
-Higher-level roles take precedence. If a `SequenceAnnotation` has a set of one or
-more roles and either its optional sibling `Component` and/or the child
+Higher-level roles take precedence. If a `SequenceAnnotation` has a set of zero
+or more roles and either its optional sibling `Component` and/or the child
 `ComponentDefinition` also has its own set of one or more roles, then the
-`SequenceAnnotation` role set completely overrides all roles on its sibling
+`SequenceAnnotation.roles` set completely overrides all roles on its sibling
 `Component` and the child `ComponentDefinition` with respect to the region
 of the parent `Sequence` annotated by that `SequenceAnnotation`. Tools must not
 merge the potentially conflicting contents of the three sets.
 
-It is RECOMMENDED to specify `role` properties on a `SequenceAnnotation` only if
-that set of roles differs from the set of roles already belonging to its
-optional sibling `Component` (if any). If a sibling `Component` exists but it
-has no roles, then it is RECOMMENDED to specify a set of `role` properties on a
-`SequenceAnnotation` only if that set differs from the set of roles already
-belonging to the child `ComponentDefinition` (if any).
+It is RECOMMENDED to specify a set of `SequenceAnnotation.roles` only if that
+set of roles differs from the set of `roles` already belonging to its optional
+sibling `Component` (if any). If a sibling `Component` exists but it has no
+declared set of `Component.roles`, then it is RECOMMENDED to specify a set of
+`SequenceAnnotation.roles` only if that set differs from the set of `role`
+elements already belonging to the child `ComponentDefinition` (if any).
 
-If a SequenceAnnotation's set of roles contain multiple URIs, then they MUST
-identify non-conflicting terms (refer to examples in the [SBOL] spec).
+If a set of `SequenceAnnotation.roles` contain multiple `role` URIs, then they
+MUST identify non-conflicting terms (refer to examples in the [SBOL] spec).
 
-### 2.3 XML Serialization
+### 2.3 XML Serialization Details
 
-For both proposed contextual role properties, the list of `<role>` elements,
-if given, MUST be contained within a single `<roles>` element in its
-serialized form. By giving us a way to override a *nonempty* set of child roles
-with an *empty* set of parent roles, this structure allows us to specify that a
-child `ComponentDefinition` whose designer declared some role(s) actually has
-*no role* in the given parent context. An empty `<roles>` element implies an
-empty set of contextual roles for the purposes of applying the precedence rules
-in subsections 2.1 and 2.2; the empty element specifies that there are *no*
-roles in the current context. An empty `<roles>` element is not equivalent
-to an absent one.
+For both proposed contextual `roles` properties, a set of zero or more `<role>`
+child elements, if declared, MUST be contained within a single `<roles>` element
+in the XML serialized form.
+
+To declare that a `Component` or `SequenceAnnotation` has zero roles in the
+current context, encode that empty set with a childless `<roles`> element. To
+refrain from specifying a set of roles, include no `<roles>` element at all.
+
+N.B. An empty `<roles>` element is not equivalent to an absent one. An empty
+`<roles>` element positively implies an empty set of contextual roles for the
+purposes of applying the precedence rules in subsections 2.1 and 2.2.
+
+By providing a way to override a *nonempty* set of child roles with an *empty*
+set of parent roles, this data structure allows us to specify that a child
+`ComponentDefinition` whose designer declared some role(s) actually lacks those
+role(s) in the current context.
 
 ### 2.4 Editorial remark
 
@@ -257,7 +268,7 @@ sequence used for immunostaining.
 --------------------------
 
 There are no obvious backwards compatibility issues. Contextual roles require
-an additional field on both `Component` and `SequenceAnnotation`. These fields
+additional fields on both `Component` and `SequenceAnnotation`. These fields
 can be safely ignored by software tools written for [SBOL] 2.0.
 
 


### PR DESCRIPTION
The previous PR contained some linguistic stragglers from previous revisions of SEP 004, where the set-theoretical aspects of this proposal weren't explicitly worked out. This version nails it all down.

Also reorganized a few subsections.