### PR TITLE
SEP 004: Eliminate certain default values.

### DIFF
--- a/sep_004.md
+++ b/sep_004.md
@@ -149,10 +149,9 @@ The `Component.roles` property comprises an OPTIONAL set of zero or more
 URIs describing the purpose or potential function of a given child
 `ComponentDefinition` in the context of its parent `ComponentDefinition`.
 
-If provided, these `role` URIs
-MUST identify terms from appropriate ontologies. Roles are not restricted to
-describing biological function; they may annotate Components' function in any
-domain for which an ontology exists.
+If provided, these `role` URIs MUST identify terms from appropriate ontologies.
+Roles are not restricted to describing biological function; they may annotate
+Components' function in any domain for which an ontology exists.
 
 It is RECOMMENDED that these `role` URIs identify terms that are compatible with
 the `type` properties of both the parent and child ComponentDefinitions. For
@@ -164,21 +163,26 @@ given in the [SBOL] specification.
 
 ### 2.1.1 Component.roleIntegration
 
-The `Component.roleIntegration` property is OPTIONAL and has a data type of URI.
-Each `Component` instance MAY specify the relationship between its own set
-set of `roles` and the set of `roles` on the child `ComponentDefinition`.
+The `Component.roleIntegration` property has a data type of URI. A `Component`
+instance with zero `roles` MAY OPTIONALLY specify a `roleIntegration`. A
+`Component` instance with one or more `roles` MUST specify a `roleIntegration`
+from the table below.
+
+A `roleIntegration` specifies the relationship between a `Component` instance's
+own set set of `roles` and the set of `roles` on the child
+`ComponentDefinition`.
 
 | Integration URI                   | Description |
 |-----------------------------------|-------------|
 | http://sbols.org/v2#overrideRoles | In the context of this `Component`, ignore any role(s) given for the child `ComponentDefinition`. Instead use only the set of zero or more roles given for this `Component`. |
-| http://sbols.org/v2#mergeRoles    | Use the union of the two sets: both the set of zero or more roles given for this `Component` as well as the set of zero or more roles given for the child `ComponentDefinition`. (Default value.) |
+| http://sbols.org/v2#mergeRoles    | Use the union of the two sets: both the set of zero or more roles given for this `Component` as well as the set of zero or more roles given for the child `ComponentDefinition`. |
 
-If no `roleIntegration` is given, then
-`http://sbols.org/v2#mergeRoles` is assumed.
+If zero `Component.roles` are given and no `Component.roleIntegration` is
+given, then `http://sbols.org/v2#mergeRoles` is assumed.
 
-It is RECOMMENDED to specify a set of `Component.roles` only if the
-integrated result set of roles would differ from the set of `roles` belonging
-to the child `ComponentDefinition`.
+It is RECOMMENDED to specify a set of `Component.roles` only if the integrated
+result set of roles would differ from the set of `roles` belonging to the child
+`ComponentDefinition`.
 
 
 ### 2.2.0 SequenceAnnotation.roles
@@ -204,9 +208,13 @@ specification.
 
 ### 2.2.1 SequenceAnnotation.roleIntegration
 
-The `SequenceAnnotation.roleIntegration` property is OPTIONAL and has a data
-type of URI. Each `SequenceAnnotation` instance MAY specify the relationship
-between its own set of roles and the set of roles computed for the
+The `SequenceAnnotation.roleIntegration` property has a data type of URI. A
+`SequenceAnnotation` instance with zero `roles` MAY OPTIONALLY specify a
+`roleIntegration`. A `SequenceAnnotation` instance with one or more `roles` MUST
+specify a `roleIntegration` from the table below.
+
+Using `roleIntegration`, a `SequenceAnnotation` instance MAY specify the
+relationship between its own set of roles and the set of roles computed for the
 sibling `Component` (if given). The integrated result set of computed roles may
 include `role` elements from the child `ComponentDefinition` if dictated by the
 value of `Component.roleIntegration`. To determine the integrated role set for a
@@ -218,9 +226,10 @@ the empty set.
 | Integration URI                   | Description |
 |-----------------------------------|-------------|
 | http://sbols.org/v2#overrideRoles | In the context of this `SequenceAnnotation`, ignore the integrated set of roles computed for the optional sibling `Component`. Instead use only the set of zero or more `roles` given for this `SequenceAnnotation`. |
-| http://sbols.org/v2#mergeRoles    | Use the union of the two sets: both the set of zero or more `roles` given for this `SequenceAnnotation` as well as the integrated set of zero or more roles computed for the optional sibling `Component`. (Default value.) |
+| http://sbols.org/v2#mergeRoles    | Use the union of the two sets: both the set of zero or more `roles` given for this `SequenceAnnotation` as well as the integrated set of zero or more roles computed for the optional sibling `Component`. |
 
-If no `roleIntegration` is given, then
+If zero `SequenceAnnotation.roles` are given and no
+`SequenceAnnotation.roleIntegration` is given, then
 `http://sbols.org/v2#mergeRoles` is assumed.
 
 It is RECOMMENDED to specify a set of `SequenceAnnotation.roles` only if
@@ -374,6 +383,10 @@ being an altogether different beast: `verifyIdentical` would impose a constraint
 implying a validation rule, as opposed to `mergeRoles` and `overrideRoles`,
 which simply name functions which, given multiple sets of roles, return a single
 set of roles.
+
+For compatibility with [SBOL] 2.0 documents, a `roleIntegration` is not required
+if no contextual roles are given. Because [SBOL] avoids specifying default
+values, an explicit `roleIntegration` is required if contextual roles are given.
 
 
 6. Competing SEPs


### PR DESCRIPTION
Per a suggestion by Chris Myers, do not have default roleIntegration values if roles are specified. Be explicit. However, for backwards compatibility with SBOL 2.0 docs, allow implicit roleIntegrations (a no-op 'merge') if no roles are listed, i.e. if the empty set is implicitly given.