### PR TITLE
SEP 004: Delete a line mistakenly duplicated in the XML serialization example.

### DIFF
--- a/sep_004.md
+++ b/sep_004.md
@@ -264,7 +264,6 @@ parent element in the XML serialized form.
 
 ### 2.3.1 XML Serialization Example
 
-    <!-- A "parent" ComponentDefinition. -->
     <sbol:ComponentDefinition rdf:about="...">
 
         ... properties specifed in [SBOL] 7.7 ...
@@ -298,7 +297,6 @@ parent element in the XML serialized form.
 
     </sbol:ComponentDefinition>
 
-    <!-- Every Component instance has one "child" ComponentDefinition. -->
     <sbol:ComponentDefinition rdf:about="...">
 
         ... properties specifed in [SBOL] 7.7 ...
@@ -412,10 +410,6 @@ On August 11, 2016, Mike Bissell deleted the following line from the second
 
 This SEP does *not* specify a ComponentDefinition.roleIntegration property. The
 deleted line was the result of a copy/paste error.
-
-Also on August 11, 2016, Mike Bissell added identifying comments verbatim from
-the class diagram image to each ComponentDefinition in the serialization
-example, in order to clarify the relationship between the text and the image.
 
 
 6. Competing SEPs

--- a/sep_004.md
+++ b/sep_004.md
@@ -10,7 +10,7 @@ SEP                   | 004
 **Replaces**          |
 **Status**            | Draft
 **Created**           | 10-Oct-2015
-**Last modified**     | 28-Apr-2016
+**Last modified**     | 11-Aug-2016
 
 Abstract
 --------
@@ -264,6 +264,7 @@ parent element in the XML serialized form.
 
 ### 2.3.1 XML Serialization Example
 
+    <!-- A "parent" ComponentDefinition. -->
     <sbol:ComponentDefinition rdf:about="...">
 
         ... properties specifed in [SBOL] 7.7 ...
@@ -297,13 +298,12 @@ parent element in the XML serialized form.
 
     </sbol:ComponentDefinition>
 
-
+    <!-- Every Component instance has one "child" ComponentDefinition. -->
     <sbol:ComponentDefinition rdf:about="...">
 
         ... properties specifed in [SBOL] 7.7 ...
 
         zero or more <sbol:role rdf:resource="..."/> elements
-        zero or one <sbol:roleIntegration rdf:resource="..."/> element
 
     </sbol:ComponentDefinition>
 
@@ -401,6 +401,21 @@ set of roles.
 For compatibility with [SBOL] 2.0 documents, a `roleIntegration` is not required
 if no contextual roles are given. Because [SBOL] avoids specifying default
 values, an explicit `roleIntegration` is required if contextual roles are given.
+
+
+### 5.3 Errata
+
+On August 11, 2016, Mike Bissell deleted the following line from the second
+`ComponentDefinition` above, at the end of the serialization example:
+
+    zero or one <sbol:roleIntegration rdf:resource="..."/> element
+
+This SEP does *not* specify a ComponentDefinition.roleIntegration property. The
+deleted line was the result of a copy/paste error.
+
+Also on August 11, 2016, Mike Bissell added identifying comments verbatim from
+the class diagram image to each ComponentDefinition in the serialization
+example, in order to clarify the relationship between the text and the image.
 
 
 6. Competing SEPs

--- a/sep_004.md
+++ b/sep_004.md
@@ -408,8 +408,12 @@ On August 11, 2016, MB deleted the following line from the second
 
     zero or one <sbol:roleIntegration rdf:resource="..."/> element
 
-This SEP does *not* specify a ComponentDefinition.roleIntegration property. The
-deleted line was the result of a copy/paste error.
+This SEP does *not* specify a ~~ComponentDefinition.roleIntegration~~ property.
+The deleted line was the result of a copy/paste error.
+
+On August 11, 2016, MB reordered two of the properties in the
+`SequenceAnnotation` serialization example, so that the new properties appear
+after the last property specified in [SBOL] 7.7.4.
 
 On August 16, 2016, MB deleted the unintentionally duplicated word
 'set' from the specification of Component.roleIntegration.

--- a/sep_004.md
+++ b/sep_004.md
@@ -183,7 +183,7 @@ instance with zero `roles` MAY OPTIONALLY specify a `roleIntegration`. A
 from the table below.
 
 A `roleIntegration` specifies the relationship between a `Component` instance's
-own set set of `roles` and the set of `roles` on the child
+own set of `roles` and the set of `roles` on the child
 `ComponentDefinition`.
 
 | Integration URI                   | Description |

--- a/sep_004.md
+++ b/sep_004.md
@@ -10,7 +10,7 @@ SEP                   | 004
 **Replaces**          |
 **Status**            | Draft
 **Created**           | 10-Oct-2015
-**Last modified**     | 11-Aug-2016
+**Last modified**     | 16-Aug-2016
 
 Abstract
 --------
@@ -403,13 +403,16 @@ values, an explicit `roleIntegration` is required if contextual roles are given.
 
 ### 5.3 Errata
 
-On August 11, 2016, Mike Bissell deleted the following line from the second
+On August 11, 2016, MB deleted the following line from the second
 `ComponentDefinition` above, at the end of the serialization example:
 
     zero or one <sbol:roleIntegration rdf:resource="..."/> element
 
 This SEP does *not* specify a ComponentDefinition.roleIntegration property. The
 deleted line was the result of a copy/paste error.
+
+On August 16, 2016, MB deleted the unintentionally duplicated word
+'set' from the specification of Component.roleIntegration.
 
 
 6. Competing SEPs

--- a/sep_004.md
+++ b/sep_004.md
@@ -288,8 +288,8 @@ parent element in the XML serialized form.
 
                 ... properties specified in [SBOL] 7.7.4 ...
 
-                zero or more <sbol:role rdf:resource="..."/> elements
                 zero or one <sbol:component rdf:resource="..."/> element
+                zero or more <sbol:role rdf:resource="..."/> elements
                 zero or one <sbol:roleIntegration rdf:resource="..."/> element
 
             </sbol:SequenceAnnotation>


### PR DESCRIPTION
Added a section 5.3: Errata explaining why this line, mistakenly copied and pasted into the wrong place, needed to go.