### PR TITLE
Update SEP statuses from draft to Accepted/Withdrawn as marked in Issues

### DIFF
--- a/sep_004.md
+++ b/sep_004.md
@@ -8,7 +8,7 @@ SEP                   | 004
 **Type**              | Data Model
 **SBOL Version**      | 2.1.0
 **Replaces**          |
-**Status**            | Draft
+**Status**            | Accepted
 **Created**           | 10-Oct-2015
 **Last modified**     | 16-Aug-2016
 

--- a/sep_007.md
+++ b/sep_007.md
@@ -8,7 +8,7 @@ SEP                     | <leave empty>
 **Editor**            | Raik Gruenberg
 **Type**               | Data Model
 **SBOL Version** | 2.2
-**Status**             | Complete
+**Status**             | Accepted
 **Created**          | 19-Aug-2016
 **Last modified**  | 12-Sep-2017
 

--- a/sep_009.md
+++ b/sep_009.md
@@ -8,7 +8,7 @@ SEP                     | 009
 **Editor**            | James Alastair McLaughlin (j.a.mclaughlin@ncl.ac.uk) 
 **Type**               | Data Model
 **SBOL Version** | 2
-**Status**             | Draft
+**Status**             | Accepted
 **Created**          | 20-Sep-2016
 **Last modified**  | 
 

--- a/sep_012.md
+++ b/sep_012.md
@@ -9,7 +9,7 @@ SEP                     | <leave empty>
 **Type**               | Data Model
 **SBOL Version** | 2.1
 **Replaces**        | n/a 
-**Status**             | Draft
+**Status**             | Accepted
 **Created**          | 14-Dec-2016
 **Last modified**  | First submission
 

--- a/sep_016.md
+++ b/sep_016.md
@@ -10,7 +10,7 @@ SEP                   | <leave empty>
 **Type**              | Data Model
 **SBOL Version**      | 2.3
 **Replaces**          | SEP 014
-**Status**            | Withdrawn, replaced by SEP 19
+**Status**            | Withdrawn, replaced by SEP 20
 **Created**           | 04-Sep-2017
 **Last modified**     | 07-Nov-2017
 

--- a/sep_016.md
+++ b/sep_016.md
@@ -10,7 +10,7 @@ SEP                   | <leave empty>
 **Type**              | Data Model
 **SBOL Version**      | 2.3
 **Replaces**          | SEP 014
-**Status**            | Draft
+**Status**            | Withdrawn, replaced by SEP 20
 **Created**           | 04-Sep-2017
 **Last modified**     | 07-Nov-2017
 

--- a/sep_016.md
+++ b/sep_016.md
@@ -10,7 +10,7 @@ SEP                   | <leave empty>
 **Type**              | Data Model
 **SBOL Version**      | 2.3
 **Replaces**          | SEP 014
-**Status**            | Withdrawn, replaced by SEP 20
+**Status**            | Withdrawn, replaced by SEP 19
 **Created**           | 04-Sep-2017
 **Last modified**     | 07-Nov-2017
 

--- a/sep_017.md
+++ b/sep_017.md
@@ -10,7 +10,7 @@ SEP                   | <leave empty>
 **Type**              | Data Model
 **SBOL Version**      | 2.3
 **Replaces**          | N/A
-**Status**            | Draft
+**Status**            | Withdrawn
 **Created**           | 10-Nov-2017
 **Last modified**     | 13-Nov-2017
 

--- a/sep_018.md
+++ b/sep_018.md
@@ -8,7 +8,7 @@ SEP                     | <leave empty>
 **Editor**            | Nicholas Roehner (nicholasroehner@gmail.com)
 **Type**              | Data Model
 **SBOL Version**      | 2.2
-**Status**            | Final Draft
+**Status**            | Accepted
 **Created**           | 13-Sep-2017
 **Last modified**     | 13-Nov-2017
 

--- a/sep_019.md
+++ b/sep_019.md
@@ -10,7 +10,7 @@ SEP                   | <leave empty>
 **Type**              | Data Model
 **SBOL Version**      | 2.3
 **Replaces**          | SEP 014, SEP 016, SEP 017, SEP 018
-**Status**            | Draft
+**Status**            | Accepted
 **Created**           | 10-Nov-2017
 **Last modified**     | 11-Dec-2017
 


### PR DESCRIPTION
There are a number of SEPs that still list their status as being a Draft, despite the corresponding Issue apparently indicating that they have progressed to being either Accepted or Withdrawn.

This pull request updates these statuses.