### PR TITLE
Create SEP_003.md

### DIFF
--- a/SEP_003.md
+++ b/SEP_003.md
@@ -1,0 +1,174 @@
+# SEP 003 -- SBOL Governance Update
+
+| SEP | 003 |
+| --- | --- |
+| **Title** | SBOL Governance Update |
+| **Authors** | Jacob Beal (jakebeal@bbn.com) |
+| **Type** | Procedure |
+| **Status** | Final |
+| **Created** | 13-Oct-2015 |
+| **Last modified** | 15-Oct-2015 |
+## Abstract
+
+This document proposes a thorough updating and revision of the SBOL governance documents at [1](http://sbolstandard.org/development/gov/).
+The key changes in this document are:
+- Create a steering committee that recognizes the de facto strategic coordination carried out by key PIs and makes it an open and inclusive process
+- Clarify the role and term of the SBOL Chair --- in particular, as head of the steering committee
+- Editors meetings should be open, and we should post minutes again
+- Recognize a number of de facto changes that the community has made in its structure and processes since the original document was drafted
+- Explicitly state core values of openness and diversity
+## Table of Contents
+- [1. Rationale](#rationale)
+- [2. Governance](#specification)
+  - 2.1 SBOL Organization
+  - 2.2 SBOL Development Group
+  - 2.3 Ad-Hoc Subgroups
+  - 2.4 SBOL Editors
+  - 2.5 SBOL Chair and Steering Committee
+  - 2.6 Voting Procedures
+- [3. Discussion](#discussion)
+- [References](#references)
+- [Copyright](#copyright)
+## 1. Rationale <a name="rationale"></a>
+
+The current SBOL governance documents are rather incomplete and do not reflect the consensus state of practice in how the community is governing itself.  This SEP attempts to fill out important missing information (e.g., quorum for votes, purpose of the SBOL Chair), and also to recognize and legitimate current practices (e.g., editors are elected by a vote organized via the mailing list, not by consensus at a workshop).
+
+If adopted, the “Governance” section will replace the text of the governance document at [1](http://sbolstandard.org/development/gov/).
+## 2. Governance <a name="specification"></a>
+
+SBOL is being developed by a generally collegial volunteer organization, which runs primarily by rough consensus.  As an organization, the SBOL development community holds the following values:
+- SBOL should be free and open standard developed by open and inclusive processes.
+- SBOL is a community that believes in fostering, cultivating and preserving a culture of diversity and inclusion.
+- Leaders of the SBOL community are expected to actively foster a safe environment where all participants feel comfortable making their voices heard.
+- Leadership from new and diverse voices should be actively developed, including by participation in working groups and by public speaking at workshops.
+  In order to ensure effective development of SBOL that conforms with these values, the SBOL community has adopted the following regulations for its governance (last amended on DATE):
+## SBOL Organization
+
+The SBOL community has the following organization:
+- SBOL Development Group: general body comprising all members of the SBOL community, and ultimate authority
+- Ad-Hoc Subgroups: portions of the general development group focused on particular aspects of SBOL development.
+- SBOL Editors: operational executives for the community
+- SBOL Chair and Steering Committee: strategic planning and guidance for the community
+## SBOL Development Group
+
+Membership in the SBOL Development Group is open to all interested parties. Individuals interested in joining the group should contact the editors (editors@sbolstandard.org).
+
+The SBOL Development Group as a whole is the ultimate authority and source of legitimacy for SBOL standards decisions.  All elections, standards changes, and governance changes are voted on by the SBOL Development Group according to the procedures below.
+
+The primary means of communication for the SBOL Development Group is via the sbol-dev Google Group.  All significant decisions on governance and the evolution of the standard must be discussed via this mailing list.
+
+SBOL workshops should be held twice per year.  These may be stand-alone workshops or in combination with another event, but must provide ample time for attending members to hold focused discussions on the development of SBOL.
+
+All members of the SBOL Development Group are encouraged (but not required) to:
+1. Attend the SBOL Workshops and other meetings
+    2. Participate in discussions on SBOL mailing lists
+    3. Support the SBOL standard in any tools and systems they work on
+    4. Provide constructive feedback for improving the standard
+## Ad-Hoc Subgroups
+
+Certain activities of the SBOL community are expected to either generate noticeably higher volumes of communication (e.g., software development and support) or to address topics expected to be of interest only to certain special interest groups.  When deemed appropriate, ad-hoc subgroups may be created for addressing such topics.  
+
+Subgroups must communicate via open lists that may be readily accessed and joined by any member of the SBOL Development Group.  Any communication regarding standards changes, however, should be migrated back to the SBOL Development Group mailing list.
+## SBOL Editors
+
+As a matter of pragmatism, many organizational decisions and actions are delegated to an elected group of SBOL Editors, so named because their primary responsibility is ensuring the effective curation of documents for the community.
+
+The responsibilities of the SBOL Editors are:
+- Equitably representing the community in voting, documents, and guidance of discussion.
+- Curation and dissemination of the SBOL standards and related documents (including writing, editing, and coordinating changes).
+- Maintaining an open and structured process by which members of the SBOL Development Group can modify and improve SBOL standards (including timely implementation of tracking, processing, responding to, and organizing voting on change proposals).
+- Ensuring effective development and maintenance of official SBOL software libraries and associated documentation and tutorials.
+- Coordinating scholarly publications and ensuring proper attribution of contributions.
+- Running elections and other community votes.
+- Organization (or delegation) of SBOL Workshops and other events.
+- Maintaining community infrastructure, including: the SBOL web site, source code repositories, mailing lists
+
+The SBOL Editors shall hold weekly meetings to coordinate their execution of these responsibilities.  These meetings should be open, and their minutes should be reported to the SBOL Development Group.
+
+The SBOL Editors mailing list is editors@sbolstandard.org.  Editorial communications should generally use this list to preserve records and aid organization.  To preserve organizational memory, former editors are kept on the mailing list until they choose to remove themselves.
+
+SBOL Editors are elected by a community vote, following the process below.  Editors serve for a two year term and cannot serve terms consecutively.  To maximize continuity, editors’ terms should be desynchronized. There are 5 editorial positions, currently held by:
+- Bryan Bartley, University of Washington
+   \* Jacob Beal, BBN Technologies
+   \* Kevin Clancy, Life Technologies
+   \* Raik Grunberg, University of Montreal 
+- Goksel Misirli, Newcastle University
+
+Previous SBOL Editors include:
+Michal Galdzicki, University of Washington, Ernst Oberortner, Boston University, Jacqueline Quinn, Google, Matthew Pocock, Newcastle University, Cesar Rodriguez, Autodesk, Nicholas Roehner, University of Utah, Mandy Wilson, Virginia Bioinformatics Institute
+## SBOL Chair and Steering Committee
+
+The positions of SBOL Chair and Steering Committee are a means for organizing strategic planning and coordination amongst PI-level members of the SBOL community.
+
+The SBOL Chair is the head of the SBOL Steering Committee.  The SBOL Chair is responsible for ensuring regular steering committee meetings are held, for effective moderation of these meetings, and for being an advertised public point of contact for outside organizations.
+The SBOL Chair is elected by a community vote, following the process below.  Chairs serve for a four year term and cannot serve terms consecutively.  In order to ensure a smooth working relationship between the SBOL Chair and SBOL Editors, the SBOL Editors can remove a chair by a no-confidence vote amongst the SBOL Editors. at any time.
+
+The rest of the SBOL Steering Committee is appointed (and removed) by the SBOL Chair.  The Steering Committee has no fixed size or fixed term, but should generally comprise the set of PI-level members who are strongly active, have a strong stake in SBOL, and are willing to assume community leadership responsibilities.  
+
+The SBOL Steering Committee shall hold monthly meetings to coordinate around strategic issues for the community (e.g., funding, setting key priorities and goals). These meetings should be open, and their minutes should be reported to the SBOL Development Group.  The SBOL Steering Committee should also convene an external advisory board to help maintain strategic links with other communities and to obtain useful advice in guiding the community.
+
+The SBOL Steering Committee mailing list is steering-committee@sbolstandard.org.  Communications should generally use this list to preserve records and aid organization.  To preserve organizational memory, former chairs and members are kept on the mailing list until they choose to remove themselves.
+
+The SBOL Chair is currently:
+- Herbert Sauro, University of Washington
+
+The SBOL Steering Committee is currently:
+- Nobody.
+## Voting Procedures
+### Elections Process:
+1. Before any election, there is a nomination period of 5 working days.
+2. All members of the SBOL Development Group are eligible for all offices (except as term-limited).
+3. Any member can self-nominate or can nominate any other member.
+4. Voting runs for 5 working days, starting at the end of the nomination period.  All members of the SBOL Development Group are eligible to vote. 
+5. Candidates are elected by plurality.
+### Voting process:
+1. Any member of the SBOL Developers Group can initiate a motion for a vote.
+2. Any other member of the SBOL Developers Group can second the motion.
+3. SBOL Editors post a voting form, for discussion and amendment over a period of 2 working days.
+4. Voting runs for 5 working days, starting at the end of the discussion period.  All members of the SBOL Development Group are eligible to vote. 
+5. The SBOL Editors may extend the voting period by up to an additional 5 working days when they feel that an insufficient number of votes have been obtained. 
+6. SBOL Editors tally and call the vote. First vote will be judged by a 67% majority to indicate “rough consensus”
+   1. If rough consensus is not reached, discussion of 3 working days is to follow.
+   2. The reasons for decisions must be recorded with the results of the vote.
+   3. Any second followup vote will be ruled 50% majority will be treated as the decision
+### Voting form must:
+1. State clearly the item being voted on.
+2. State the version and document to change (e.g. SBOL 1.1 specification) and which version target it works towards.
+3. State the eligibility criteria for voting, “All members of the SBOL Developers Group are eligible to vote.”
+4. Provide the options for the vote
+   1. Include all opinions made clear in the discussion as options.
+   2. Include an “Abstain” and “Table for Further Discussion” option.
+   3. Include a “No Change” and a “No Opinion” option when appropriate.
+   4. Include a field for entering the email address of a voter.
+   5. Include a comments field.
+## 3. Discussion <a name='discussion'></a>
+
+A draft proposal was discussed in a session at COMBINE 2015, resulting in the initial version of the document.  Significant changes from the original draft were:
+- The most important guiding principle is the first statement, that the community runs in a collegial manner by rough consensus.  Lots of concerns and possible contingencies were avoided by referring back to that statement, saying that if those become necessary (e.g., a takeover attempt by some subgroup), then the the collegial community is already gone, and governance has to be fundamentally restructured in any case.
+- A proposal for quorum was removed in favor of adding “Table for Further Discussion” as an option and giving the editors the ability to extend the voting time.
+- Elections are settled by plurality, rather than 67%, since people thought it would be silly to have lots of votes when there are multiple candidates.  If we start having problems, then we may revisit this.
+- The relationship between Chair and Editors was considered very important, and thus the Editors were given the power to remove the chair. Alternate proposals included having the Editors elect or nominate the chair, which were discarded because they felt contrary to open community.
+- The external advisory board was not part of the initial draft, but has been widely felt necessary for some time, and so was added.  People did not feel it was necessary to define precisely, but that it would be OK to basically leave it up to the steering committee to sort out details of what would work best for them.
+
+In response to mailing list discussion:
+- Added point on editors duty to equitably represent.
+## References <a name='references'></a>
+## Copyright <a name='copyright'></a>
+
+<p xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law,
+  <a rel="dct:publisher"
+     href="sbolstandard.org">
+    <span property="dct:title">SBOL developers</span></a>
+  has waived all copyright and related or neighboring rights to
+  <span property="dct:title">SEP 003</span>.
+This work is published from:
+<span property="vcard:Country" datatype="dct:ISO3166"
+      content="US" about="sbolstandard.org">
+  United States</span>.
+</p>


### PR DESCRIPTION
This commit copied SEP_003 from the comment section of the issue tracker to a real file. This will allow us to close SEP_003 out from the issue tracker while maintaining a more accessible copy of its information.