### PR TITLE
SEP 055: add non-replicating backbones

### DIFF
--- a/sep_055.md
+++ b/sep_055.md
@@ -85,7 +85,7 @@ This specification and set of practices for representation of parts and devices 
   * **Scar**: A sequence that is produced by the combination of flanking sequences in an assembly.
 
 
-* **Backbone**: A DNA construct into which parts are intended to be inserted at one or more designated insertion sites, in order to meet the requirements of an assembly. Precisely one part can be inserted at any given insertion site. In many cases, a backbone will be a circular plasmid with precisly one insertion site, but other types of vector are possible as well, such as linear plasmids or viral replicons.
+* **Backbone**: A DNA construct into which parts are intended to be inserted at one or more designated insertion sites, in order to meet the requirements of an assembly. Precisely one part can be inserted at any given insertion site. In many cases, a backbone will be a circular plasmid with precisly one insertion site, but other types of vector are possible as well, such as linear plasmids, viral replicons, or non-replicating flanking adapters.
 
   * **Drop-Out Sequence**: A portion of a backbone at an insertion site that is removed when a part is inserted at that site. Some backbones include drop-out parts while others do not.
 
@@ -131,7 +131,8 @@ The composite part should also have a `prov:wasGeneratedBy` indicating biobrick 
 
 #### Backbones <a name="backbones"></a>
 
-Like a part, a backbone is represented by an SBOL `Component` with a `type` property of `SBO:DNA`. The `role` of a backbone, however, should be `SO:vector_replicon` or one of its children (e.g., `SO:plasmid_vector`).
+Like a part, a backbone is represented by an SBOL `Component` with a `type` property of `SBO:DNA`. The `role` of a replicating backbone SHOULD be `SO:vector_replicon` or one of its children (e.g., `SO:plasmid_vector`).
+A non-replicating backbone, such as used in linear fragments with flanking sequences for restriction, SHOULD instead use `SO:engineered_region`.
 As with any `Component`, other information about the structure of the backbone is indicated by its `feature` properties.
 
 Unlike a part, a backbone does not necessarily have to have a `sequence`. 
@@ -150,6 +151,8 @@ A backbone MAY include flanking sequences for assembly at its insertion sites. E
 _Example: pSB1C3 is a Chloramphenicol-resistant high-copy plasmid used as a backbone for BioBrick assembly. It is a `Component` of type `SBO:DNA` with role `SO:plasmid_vector`. It should also have type `SO:circular`, since it is a circular plasmid. pSB1C3 includes BioBrick prefix and suffix flanking regions, that should be given role `SO:restriction_enzyme_region`._
 
 _The BioBrick prefix and suffix can be represented by a `SubComponent` that is an `instanceOf` BBa\_G00000, and the suffix be a `SubComponent` that is an `instanceOf`  BBa\_G00001, which in turn should be marked with the the EcoRI, XbaI, SpeI, and PstI recognition and cutting sites should also be marked. For example in BBa\_G00000, a `SequenceFeature` should mark bases 1-6 (gaattc) as with role `SO:restriction_enzyme_recognition_site` and another `SequenceFeature` should mark bases 2-5 (aatt) with the role `SO:five_prime_sticky_end_restriction_enzyme_cleavage_site`._
+
+_Example: A pair of flanking sequences for Type IIS assembly from fragments can be represented as a backbone `Component` of type `SBO:DNA` with role `SO:engineered_region` with threat `LocalSubComponent` objects: one for the prefix, one for the insert, and one for the suffix. The prefix and suffix objects have role `SO:restriction_enzyme_recognition_site` and are linked to `Sequence` objects specifying their content. The insert has no information about its content, but is placed between the prefix and suffix by `Constraint` relations with the `meets` restriction._
 
 ##### Part in Backbone, Inserts, and Extracts
 


### PR DESCRIPTION
Add handling for non-replicating backbones, such as flanking adapters on a linear fragment for type IIS assembly, along with an example.