### PR TITLE
Collapse "Module" into "Package" in SEP 054

### DIFF
--- a/sep_054.md
+++ b/sep_054.md
@@ -19,7 +19,6 @@ Abstract
 
 This SEP proposes a set of practices for managing collections of genetic designs (or other information encoded in SBOL). These practices approach the sharing of SBOL information in a similar way to software package managers. These practices are intended to support similar management of shared SBOL information across multiple platforms and repositories.
 
-
 Table of Contents
 ---------------------
 
@@ -84,34 +83,31 @@ This specification and set of practices for SBOL package management uses the fol
 
 * **SBOL document:** a set of SBOL TopLevel objects aggregated together such that they can be identified and retrieved by means of a single URI. This can come in multiple forms, including serialized into a file in an RDF format such as sorted N-triples, access via an online API such as a SynBioHub collection, or as a database entry.
 
-* **Module:** an SBOL document used to define a set of TopLevel objects (i.e., as opposed to one containing TopLevel objects copied from elsewhere). A module is associated with a specific namespace, and all TopLevel objects in the module must share that namespace.
+* **Package:** a systematic aggregation of SBOL materials intended to be distributed and used as a coherent whole. A package is associated with a specific namespace, and all TopLevel objects in the package must share that namespace. When stored in a hierarchical structure (e.g., files in directories), the relationship between package namespaces MUST be identical to the relationship between package locations in the structure.  Note that packages can have sub-packages.
 
-* **Package:** a systematic aggregation of modules intended to be distributed and used as a coherent whole. When stored in a hierarchical structure (e.g., files in directories), the relationship between module namespaces MUST be identical to the relationship between module locations in the structure.  Note that packages can have sub-packages.
-
-* **Root Package:** a package that is not a sub-package of any other package. Root packages are the objects directly managed by a package catalog, while sub-packages and modules are managed indirectly as part of their containing root package.
+* **Root Package:** a package that is not a sub-package of any other package. Root packages are the objects directly managed by a package catalog, while sub-packages are managed indirectly as part of their containing root package.
 
 * **Native Package:** a package whose contents are all defined in SBOL3.
 
 * **Conversion Package:** a source of non-SBOL3 material with stable URIs for retrieving objects (e.g., NCBI GenBank, UniProt, the iGEM Parts Repository), being used as package source for SBOL parts.
 Note that this also includes material encoded in prior versions of SBOL.
 
-* **Generated Content:** a set of SBOL TopLevel objects created from other information, either in SBOL (e.g., a generated module description) or external to SBOL (e.g., a converted FASTA file).
+* **Generated Content:** a set of SBOL TopLevel objects created from other information, either in SBOL (e.g., a generated package description) or external to SBOL (e.g., a converted FASTA file).
 
-* **Build Artifact:** a document derived by assembling a set of SBOL TopLevel objects from various modules and/or packages without modifying the content of the TopLevel objects therein.
+* **Build Artifact:** a document derived by assembling a set of SBOL TopLevel objects from various packages without modifying the content of the TopLevel objects therein.
 
-* **Dependency:** Statement that a module or package refers to TopLevel objects from other modules or packages. Dependencies may be declared at various levels of granularity: 
+* **Dependency:** Statement that a package refers to TopLevel objects from other packages. Dependencies may be declared at various levels of granularity: 
   * Object: only an individual TopLevel object (along with all of its child objects)
   * Object and references: a TopLevel object and all of the other TopLevel objects that it references in its definition, except for via provenance (PROV-O) relations.
-  * Module: all of the TopLevel objects in a module, implicitly including all of its dependencies
-  * Package: all of the modules in a package, implicitly including all of its dependencies
+  * Package: all of theTopLevel objects in a package, implicitly including all of its dependencies
 
-* **Direct Dependency:** A dependency that is specified in a module or package.
+* **Direct Dependency:** A dependency that is specified in a package.
 
-* **Indirect Dependency:** A dependency that is not direct, but is specified in some other recursive dependency of a module or package.
+* **Indirect Dependency:** A dependency that is not direct, but is specified in some other recursive dependency of a package.
 
 * **Atomic Package:** A package that is small enough that its contents can be readily managed and transmitted between machines as a single document.
 
-* **Dissociated Package:** A non-atomic package, i.e., one that that is too large to be used as a dependency on the module or package level, and is thus always managed on the level of objects or objects and references instead. Every dissociated package SHOULD be a conversion package. For example, the conversion package for NCBI GenBank is a dissociated package, meaning that sequences in NCBI GenBank must be referenced and imported individually.
+* **Dissociated Package:** A non-atomic package, i.e., one that that is too large to be used _in toto_ as a dependency on the package level, and is thus always managed on the level of objects or objects and references instead. Every dissociated package SHOULD be a conversion package. For example, the conversion package for NCBI GenBank is a dissociated package, meaning that sequences in NCBI GenBank must be referenced and imported individually.
 
 * **Cache:** a store for local copies of packages (or fragments thereof) obtained from elsewhere.  Caches may be shared or local to a package.  Atomic packages will generally be stored in a shared cache, while dissociated packages will generally be stored in a local cache.
 
@@ -126,72 +122,65 @@ Note that this also includes material encoded in prior versions of SBOL.
 
 `Dependency` extends the `Identified` class with the following fields:
 
-* `package` [ 1 ], URI: Package that is the dependency or contains the dependency
+* `package` [ 1 ], URI: Root package that is the dependency or contains the dependency
 * `version` [0,1], string: Statement indicating the version of the package to use. Versions SHOULD use SemVer format. If this property is not provided, then any version is considered acceptable, with the highest version preferred. **Future work: expand to include constraints as well, e.g., >=1.2, <2**
-* `module` [0,1], URI: If the dependency is or is contained within a specific sub-package or sub-module within a package, this property specifies its URI.
-* `object` [0,n], URI: If dependency is specific `TopLevel` objects rather than a complete module or package, each instance of this property indicates one of those objects.
+* `subpackage` [0,1], URI: If the dependency is or is contained within a specific sub-package within the `package`, this property specifies its URI.
+* `object` [0,n], URI: If dependency is specific `TopLevel` objects rather than a complete package, each instance of this property indicates one of those objects.
 * `includeObjectReferences` [0,1], boolean: By default, object dependencies are only to the specific object itself. If this value is set to true, then object dependencies also imply dependencies on all of the TopLevel objects recursively referred to by objects in the dependency set. For example, dependency on a plasmid implies depending on the insert it is carrying, which depends in turn on the functional units in the insert, which also depends on the basic parts like promoters, CDSs, terminators, that they contain.
 
 A dependency list MAY contain redundant or overlapping entries.
-For example, a dependency list may contain both a package and a module within that package, both a module and specific objects in the module, or even multiple entries for the same object. 
-In this case, the effective dependency list is the union of all of the individual dependencies in the list.
+For example, a dependency list may contain both a package and a supackage within that package, both a subpackage and specific objects in the subpackage, or even multiple entries for the same object. 
+In such cases, the effective dependency list is the union of all of the individual dependencies in the list.
 
-This permissive unioning behavior is intended to allow independently defined dependency lists to be safely merged, e.g., in a package that depends on two other packages.  Accordingly, a tool SHOULD NOT consider it to be an issue of there are redundancies between `Dependency` objects contained by different `Module` objects.
-A tool MAY, however, choose to warn users about redundancies within the dependencies of an individual `Module`. 
-
-#### Module
-
-`Module` extends the `Collection` class with the following fields:
-
-* `hasDependency` [0,n], URI: `Dependency` child objects
-
-The `displayId` of a `Module` SHOULD be `module`, unless it is also a `package`.
-
-Every `member` of a `Module` MUST have the same value for `hasNamespace` as the module itself.
+This permissive unioning behavior is intended to allow independently defined dependency lists to be safely merged, e.g., in a package that depends on two other packages.  Accordingly, a tool SHOULD NOT consider it to be an issue of there are redundancies between `Dependency` objects contained by different `Package` objects.
+A tool MAY, however, choose to warn users about redundancies within the dependencies of an individual `Package`. 
 
 #### Package
 
-`Package` extends the `Module` class with the following additional fields:
+`Package` extends the `Collection` class with the following fields:
 
 * `version` [0,1], string: The value of this property SHOULD use SemVer to indicate the version of this package. This property SHOULD be set if and only if a package is a root package.
 * `conversion` [ 1 ], boolean: Indicates if this is a native package (false) or conversion package (true)
 * `dissociated` [0,1], string: If not set, this is an atomic package. If set, indicates this package is a dissociated package of the type identified by the string (see practices below).
-* `hasModule` [0,n], URI: Indicates the set of `Module` objects aggregated in the `Package`. These may be either plain `Module` objects or sub-`Package` objects.
+* `hasDependency` [0,n], URI: `Dependency` child objects
+* `subPackage` [0,n], URI: Indicates the set of `Package` objects aggregated in the `Package`.
 
-The `displayId` of a `Package` SHOULD be `package`. Note that this overrides the recommendation for `Module`.
+The `displayId` of a `Package` SHOULD be `package`.
+
+Every `member` of a `Package` MUST have the same value for `hasNamespace` as the package itself.
 
 A package SHOULD have `dissociated` set only if `conversion` is also true.
 
-A package SHOULD only have values for `hasModule` if it is a native package (i.e., `conversion` is false).
+A package SHOULD only have values for `hasPackage` if it is a native package (i.e., `conversion` is false).
 
 For packages with `conversion` equal to true, the `version` property SHOULD match its major version number to the major version of the data source, where applicable. Other elements of the versioning SHOULD be used to indicate versioning of the converted material.
 
 Note that any change to the sequence of a part SHOULD be a major version change, since there is no guarantee that the part will continue to have the same behavior. There are certain circumstances where it would not be, such as correcting a bug in which a sequence was not listed correctly to begin with. To add a sequence that is expected to have better performance, do not change the sequence: add a new part and deprecate the old one.
 
-Every `Module` object pointed to by `hasModule` MUST have a `hasNamespace` that is equal to the `hasNamespace` of the `Package` object plus a `local` sub-path. For example `https://example.org/MyPackage/` might have `hasModule` values `https://example.org/MyPackage/promoters` and `https://example.org/MyPackage/regulatory/repressors`
+Every `Package` object pointed to by `subPackage ` MUST have a `hasNamespace` that is equal to the `hasNamespace` of the `Package` object plus a `local` sub-path. For example `https://example.org/MyPackage/` might have `hasPackage` values `https://example.org/MyPackage/promoters` and `https://example.org/MyPackage/regulatory/repressors`
 
 
 ### 2.3 Management Practices with Packages <a name='practices'></a>
 
-#### Defining a Module
+#### Defining a Package from a Document
 
-Given an SBOL document, a `Module` can be computed by inspecting the collection of `TopLevel` objects in the document. If all `TopLevel` objects have the same `hasNamespace` value, then they form a well-defined `Module` with identity `[namespace]/module` and `members` equal to the identities of the `TopLevel` objects.
+Given an SBOL document, a native `Package` can be computed by inspecting the collection of `TopLevel` objects in the document. If all `TopLevel` objects have the same `hasNamespace` value, then they form a well-defined `Package` with identity `[namespace]/package` and `members` equal to the identities of the `TopLevel` objects.
 
-Object dependencies for a `Module` with `includeObjectReference=true` can be computed by collecting references to `TopLevel` objects that are not contained within the module and resolving those against a catalog of packages.
+Object dependencies for a `Package` with `includeObjectReference=true` can be computed by collecting references to `TopLevel` objects that are not contained within the package and resolving those against a catalog of packages.
 Other granularities can only be explicitly defined.
 
+Conversion packages cannot be computed and need to be explicitly defined.
 
-#### Defining a Package
+#### Defining a Package as an Aggregate of Documents
 
-A native `Package` can be computed by inspecting any collection of SBOL documents, first converting each SBOL document to a `Module`, then aggregating the `Module` objects into a `Package`. For example, a `Package` can be computed from a directory of files.
+A `Package` can be computed by inspecting any collection of SBOL documents, first converting each SBOL document to a `Packages`, then aggregating the `Package` objects into another `Package` that contains them all. For example, a `Package` can be computed from a directory of files.
 
-If all of the `Module` objects' namespaces share a prefix, then they form a well-defined `Package` with identity `[namespace]/package` and with `conversion=false` and `dissociated` not set. In this case, the `Package` will have no `member` values and its `hasDependency` values will be the union of the `hasDependency` values of its modules.
+If all of the docment `Package` objects' namespaces share a prefix, then they form a well-defined `Package` with identity `[prefix]/package` and with `conversion=false` and `dissociated` not set. In this case, the `Package` will have no `member` values and its `hasDependency` values will be the union of the `hasDependency` values of its sub-packages.
 
 The `name` and `description` of a package cannot be computed. If they are desired, they need to be explicitly provided.
 
 Root packages additionally need to have their `version` explicitly provided.
 
-Conversion packages cannot be computed and need to be explicitly defined.
 Any package catalog SHOULD contain conversion packages for common conversion packages, such as NCBI GenBank and the iGEM Parts Repository (see also defining dissociated packages below).
 
 #### Defining a Dissociated Package
@@ -219,11 +208,11 @@ Behavior with respect to any other value of `dissociated` is currently undefined
 
 The materials of a native `Package` can be collated into a single SBOL document. This is a build artifact that is useful for distributing materials in order to satisfy dependencies. 
 
-This document SHOULD include the `Package` object, all of its sub-`Package` objects and subordinate `Module` objects recursively, and all of their member objects and children.
+This document SHOULD include the `Package` object, all of its sub-`Package` objects recursively, and all of their member objects and children.
 
 Which dependencies are included in the build artifact depends on the planned use of the build artifact:
 
-* For use in package cataloging and distribution, the build artifact SHOULD NOT include any materials from non-dissociated dependencies (except for dependencies between the modules of the package itself). This is because these packages may be included in multiple dependency paths. Instead, they are assumed to be able to be fetched independently during dependency resolution.
+* For use in package cataloging and distribution, the build artifact SHOULD NOT include any materials from non-dissociated dependencies (except for dependencies between the sub-packages of the package itself). This is because these packages may be included in multiple dependency paths. Instead, they are assumed to be able to be fetched independently during dependency resolution.
 
   The build artifact SHOULD, however, include all objects included as direct dependencies from dissociated package materials. This is because dissociated packages are too large to cache and SHOULD NOT be in SBOL format, meaning that repeating the fetch and conversion of a dissociated package object is not guaranteed to produce an identical object. Including them in the package guarantees stability of the package materials.
 
@@ -235,7 +224,7 @@ Which dependencies are included in the build artifact depends on the planned use
 #### Building and Using a Package Catalog
 
 A catalog of packages can be built by collecting together a set of root `Package` objects.
-To keep the catalog manageable in size, the catalog SHOULD contain only root `Package` information and SHOULD NOT contain sub-`Package` or `Module` objects or the actual contents of packages.
+To keep the catalog manageable in size, the catalog SHOULD contain only root `Package` information and SHOULD NOT contain sub-`Package` objects or the actual contents of packages.
 
 A catalog also needs to be able to track multiple versions of the same package. 
 If the catalog is to be a single document, then this means that the `Package` objects for the different versions must not share the same URI.
@@ -289,9 +278,9 @@ When building, checking, or using a `Package`, it will often be necessary to che
 
 Direct dependencies SHOULD be resolved following one of three methods, depending on the nature of the dependency.
 
-1. Any dependency with a `package` value having a prefix of the namespace of the root `Package` for a project SHOULD be resolved locally, by confirming that the required `Package`, `Module`, and/or objects are available at the expected locations within the project.
+1. Any dependency with a `package` value having a prefix of the namespace of the root `Package` for a project SHOULD be resolved locally, by confirming that the required `Package` and/or objects are available at the expected locations within the project.
 2. Any dependencies with a `package` value that precisely matches a dissociated package in the catalog SHOULD be resolved by attempting to download and convert material from its source, following the source specification for the dissociated package in the package catalog.
-3. Any dependencies with a `package` value having a prefix of the namespace of atomic package in the catalog are resolved by locating the package in the catalog, confirming that a copy has been cached locally, and confirming that the required `Package`, `Module`, and/or objects are available from the specified package.
+3. Any dependencies with a `package` value having a prefix of the namespace of atomic package in the catalog are resolved by locating the package in the catalog, confirming that a copy has been cached locally, and confirming that the required `Package` and/or objects are available from the specified package.
 
 Any direct dependency that does not resolve following one of these methods SHOULD be considered an error condition.
 
@@ -305,7 +294,7 @@ Conflicts between dependencies (direct or indirect) can arise in two ways:
 In either case, such a conflict is an error condition and needs to be resolved manually.
 
 
-#### Storing Modules and Packages Within a Directory Tree
+#### Storing Packages Within a Directory Tree
 
 When package materials are stored in a hierarchical directory structure, it is useful to distinguish user-authored and tool-created content.  User-authored content SHOULD be primary in the structure, while all tool-created content is potentially subject to deletion and reconstruction. It is thus RECOMMENDED that tool-created content be stored in a hidden subdirectory of the directory for which the content has been created.
 
@@ -317,15 +306,15 @@ Generated content, while tool-created, consists of novel SBOL objects not stored
 
 When built with respect to a specific directory, generated content SHOULD be stored in a hidden subdirectory named `.sip`.
 
-Each `Package` and its associated `Module` objects (but not sub-packages), SHOULD be stored in sorted N-triples format in a file named `.sip/package.nt`.
+Each `Package` and its associated filed-derived sub-`Package` objects (but not sub-directory derived sub-packages), SHOULD be stored in sorted N-triples format in a file named `.sip/package.nt`.
 
-Any user-defined material for the package (e.g., name, version) SHOULD be provided in a file named `package.EXT` in the package directory where `EXT` is any valid SBOL extension and that contains precisely one `TopLevel` object: the user-defined `Package` object.  If this file is present, then the `Package` object in `.sip/package.nt` file should be generated by starting with the user-derined `Package` and adding `hasModule` and `hasDependency` properties based on the contents of the directory.
+Any user-defined material for the package (e.g., name, version) SHOULD be provided in a file named `package.EXT` in the package directory where `EXT` is any valid SBOL extension and that contains precisely one `TopLevel` object: the user-defined `Package` object.  If this file is present, then the `Package` object in `.sip/package.nt` file should be generated by starting with the user-derined `Package` and adding `subPackage` and `hasDependency` properties based on the contents of the directory.
 
 Imports from a dissociated package X SHOULD be stored in sorted N-triples format in a file named `.sip/X.nt`
 
-Genetic design documents stored in a format other than SBOL3 (e.g., Excel, SBOL2) SHOULD have their derivative SBOL3 documents stored in the `.sip` package as well.  For example if a module is defined in an Excel file named `my_module.xlsx`, an Excel-to-SBOL export of `my_module.nt` would be stored in the `.sip` package.
+Genetic design documents stored in a format other than SBOL3 (e.g., Excel, SBOL2) SHOULD have their derivative SBOL3 documents stored in the `.sip` package as well.  For example if a package is defined in an Excel file named `my_package.xlsx`, an Excel-to-SBOL export of `my_package.nt` would be stored in the `.sip` package.
 
-The `.sip` directory MUST contain nothing besides the `package.nt`, dissociated package files, and converted modules.
+The `.sip` directory MUST contain nothing besides the `package.nt`, dissociated package files, and converted packages.
 The directory MAY, of course, omit these files before they have been built.
 The contents of each dissociated package files SHOULD contain precisely the set of dependencies indicated for that package in `package.nt`.
 


### PR DESCRIPTION
Discussion on the SBOL3 call led to a conclusion that "Module" was an unnecessary layer before "Package".

This set of edits eliminates Module and folds all of its usages into Package.
