### PR TITLE
Add restrictions to the naming of packages

### DIFF
--- a/sep_054.md
+++ b/sep_054.md
@@ -157,6 +157,8 @@ A tool MAY, however, choose to warn users about redundancies within the dependen
 
 The `displayId` of a `Package` SHOULD be `package`.
 
+To avoid potential confusion between packages with similar names, the identity URI of a package SHOULD be lower-case ASCII, and the path elements of the URI SHOULD be only alphanumeric or dash characters (e.g., `https://igem.org/fluorescent-proteins/package`).
+
 Every `member` of a `Package` MUST have the same value for `hasNamespace` as the package itself.
 
 A package SHOULD have `dissociated` set only if `conversion` is also true.


### PR DESCRIPTION
Add restrictions to the naming of packages, in order to decrease likelihood of name confusion